### PR TITLE
Added dynamic validation attributes using form object

### DIFF
--- a/legacy_tests/Browser/SupportDynamicValidationAttributes/Component.php
+++ b/legacy_tests/Browser/SupportDynamicValidationAttributes/Component.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LegacyTests\Browser\SupportDynamicValidationAttributes;
+
+use Illuminate\Support\Facades\View;
+use Livewire\Component as BaseComponent;
+
+class Component extends BaseComponent
+{
+    public TestFormWithDynamicValidationAttributes $dynamicForm;
+
+    public TestFormWithoutDynamicAttributes $defaultForm;
+
+    public function dynamicValidation()
+    {
+        $this->dynamicForm->validate();
+    }
+
+    public function defaultValidation()
+    {
+        $this->defaultForm->validate();
+    }
+
+    public function render()
+    {
+        return View::file(__DIR__ . '/view.blade.php');
+    }
+}

--- a/legacy_tests/Browser/SupportDynamicValidationAttributes/Test.php
+++ b/legacy_tests/Browser/SupportDynamicValidationAttributes/Test.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace LegacyTests\Browser\SupportDynamicValidationAttributes;
+
+use Livewire\Livewire;
+use LegacyTests\Browser\TestCase;
+
+class Test extends TestCase
+{
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function test()
+    {
+        $this->browse(function ($browser) {
+            $this->visitLivewireComponent($browser, Component::class)
+                ->waitForLivewire()->click('@dynamicForm')
+                ->assertSeeIn('@output.dynamic.form.name', 'Field Title is must.')
+                ->assertSeeIn('@output.dynamic.form.body', 'Description')
+
+                ->waitForLivewire()->click('@defaultForm')
+                ->assertSeeIn('@output.default.form.name', 'The Title field is must.')
+                ->assertSeeIn('@output.default.form.body', 'The Description field is required.');
+        });
+    }
+}

--- a/legacy_tests/Browser/SupportDynamicValidationAttributes/TestFormWithDynamicValidationAttributes.php
+++ b/legacy_tests/Browser/SupportDynamicValidationAttributes/TestFormWithDynamicValidationAttributes.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LegacyTests\Browser\SupportDynamicValidationAttributes;
+
+use Livewire\Attributes\Rule;
+use Livewire\Form;
+
+class TestFormWithDynamicValidationAttributes extends Form
+{
+    #[Rule('required')]
+    public $name;
+
+    #[Rule('required')]
+    public $body;
+
+    public function validationAttributes(): array
+    {
+        return [
+            'name' => 'Title',
+            'body' => 'Description',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'Field :attribute is must.',
+        ];
+    }
+}

--- a/legacy_tests/Browser/SupportDynamicValidationAttributes/TestFormWithoutDynamicAttributes.php
+++ b/legacy_tests/Browser/SupportDynamicValidationAttributes/TestFormWithoutDynamicAttributes.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace LegacyTests\Browser\SupportDynamicValidationAttributes;
+
+use Livewire\Attributes\Rule;
+use Livewire\Form;
+
+class TestFormWithoutDynamicAttributes extends Form
+{
+    #[Rule('required', as: 'Title', message: 'The :attribute field is must.')]
+    public $name;
+
+    #[Rule('required', as: 'Description')]
+    public $body;
+}

--- a/legacy_tests/Browser/SupportDynamicValidationAttributes/view.blade.php
+++ b/legacy_tests/Browser/SupportDynamicValidationAttributes/view.blade.php
@@ -1,0 +1,19 @@
+<div>
+    <form wire:submit="dynamicValidation">
+        <label for="dynamicForm.name">Name</label>
+        <input wire:model="dynamicForm.name" dusk="dynamicForm.name" id="dynamicForm.name" type="text"><span dusk="output.dynamic.form.name">@error('dynamicForm.name') {{ $message }} @enderror</span>
+
+        <label for="dynamicForm.body">Body</label>
+        <textarea wire:model="dynamicForm.body" id="dynamicForm.body" type="text"></textarea><span dusk="output.dynamic.form.body">@error('dynamicForm.body') {{ $message }} @enderror</span>
+        <button type="submit" dusk="dynamicForm">Submit</button>
+    </form>
+
+    <form wire:submit="defaultValidation">
+        <label for="defaultForm.name">Name</label>
+        <input wire:model="defaultForm.name" dusk="defaultForm.name" id="defaultForm.name" type="text"><span dusk="output.default.form.name">@error('defaultForm.name') {{ $message }} @enderror</span>
+
+        <label for="defaultForm.body">Body</label>
+        <textarea wire:model="defaultForm.body" id="defaultForm.body" type="text"></textarea><span dusk="output.default.form.body">@error('defaultForm.body') {{ $message }} @enderror</span>
+        <button type="submit" dusk="defaultForm">Submit</button>
+    </form>
+</div>

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -13,6 +13,8 @@ class Form implements Arrayable
         protected $propertyName
     ) {
         $this->addValidationRulesToComponent();
+        $this->addValidationAttributesToComponent();
+        $this->addMessagesToComponent();
     }
 
     public function getComponent() { return $this->component; }

--- a/src/Features/SupportFormObjects/Form.php
+++ b/src/Features/SupportFormObjects/Form.php
@@ -25,13 +25,33 @@ class Form implements Arrayable
         if (method_exists($this, 'rules')) $rules = $this->rules();
         else if (property_exists($this, 'rules')) $rules = $this->rules;
 
-        $rulesWithPrefixedKeys = [];
+        $this->component->addRulesFromOutside(
+            $this->getAttributesWithPrefixedKeys($rules)
+        );
+    }
 
-        foreach ($rules as $key => $value) {
-            $rulesWithPrefixedKeys[$this->propertyName . '.' . $key] = $value;
-        }
+    public function addValidationAttributesToComponent()
+    {
+        $validationAttributes = [];
 
-        $this->component->addRulesFromOutside($rulesWithPrefixedKeys);
+        if (method_exists($this, 'validationAttributes')) $validationAttributes = $this->validationAttributes();
+        else if (property_exists($this, 'validationAttributes')) $validationAttributes = $this->validationAttributes;
+
+        $this->component->addValidationAttributesFromOutside(
+            $this->getAttributesWithPrefixedKeys($validationAttributes)
+        );
+    }
+
+    public function addMessagesToComponent()
+    {
+        $messages = [];
+
+        if (method_exists($this, 'messages')) $messages = $this->messages();
+        else if (property_exists($this, 'messages')) $messages = $this->messages;
+
+        $this->component->addMessagesFromOutside(
+            $this->getAttributesWithPrefixedKeys($messages)
+        );
     }
 
     public function validate()
@@ -46,6 +66,9 @@ class Form implements Arrayable
             $filteredRules[$key] = $value;
         }
 
+        $this->addValidationAttributesToComponent();
+        $this->addMessagesToComponent();
+
         return $this->component->validate($filteredRules)[$this->propertyName];
     }
 
@@ -57,5 +80,16 @@ class Form implements Arrayable
     public function toArray()
     {
         return Utils::getPublicProperties($this);
+    }
+
+    protected function getAttributesWithPrefixedKeys($attributes)
+    {
+        $attributesWithPrefixedKeys = [];
+
+        foreach ($attributes as $key => $value) {
+            $attributesWithPrefixedKeys[$this->propertyName . '.' . $key] = $value;
+        }
+
+        return $attributesWithPrefixedKeys;
     }
 }


### PR DESCRIPTION
Added PR for dynamic validation attributes usage from Form Objects. [#5811](https://github.com/livewire/livewire/discussions/5811)

Currently, dynamic attributes is available form component itself but not from form object
